### PR TITLE
fix: replace deprecated readfp with read_file in configure_terminal

### DIFF
--- a/frotz.py
+++ b/frotz.py
@@ -270,9 +270,8 @@ class VTE(Vte.Terminal):
         conf_file = os.path.join(env.get_profile_path(), 'terminalrc')
 
         if os.path.isfile(conf_file):
-            f = open(conf_file, 'r')
-            conf.readfp(f)
-            f.close()
+            with open(conf_file, 'r') as f:
+                conf.read_file(f) 
         else:
             conf.add_section('terminal')
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
 
 from sugar3.activity import bundlebuilder
-bundlebuilder.start('Frotz')
+bundlebuilder.start()
 


### PR DESCRIPTION
## Summary

This pull request addresses an issue where the configure_terminalwas using the deprecated readfp method from the ConfigParser module. The readfp method was deprecated in Python 3.2 and removed in Python 3.9, causing compatibility issues with newer Python versions.

## Changes

- Corrected setup.py and removed the extra argument.
- Updated with new syntax on readfp.

## Testing
- [x] Tested locally by installing on arch.